### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for Google Cloud Datastore that provides simple query capabilities.
 
+<a href="https://glama.ai/mcp/servers/@johnreitano/daisy">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@johnreitano/daisy/badge" alt="Datastore Server MCP server" />
+</a>
+
 ## Features
 
 - **List Kinds**: Get all available entity kinds (tables) in your Datastore


### PR DESCRIPTION
This PR adds a badge for the [MCP Datastore Server](https://glama.ai/mcp/servers/@johnreitano/daisy) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@johnreitano/daisy">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@johnreitano/daisy/badge" alt="Datastore Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.